### PR TITLE
fix(docker/alpine): add missing dependency

### DIFF
--- a/docker/openwec-alpine.Dockerfile
+++ b/docker/openwec-alpine.Dockerfile
@@ -38,6 +38,7 @@ ENV APP_USER=openwec
 
 RUN apk upgrade --no-cache && apk add --no-cache \
     libgcc \
+    libsasl \
     libssl3 libcrypto3 \
     krb5-libs \
     && addgroup $APP_USER \


### PR DESCRIPTION
This is required as without it `openwecd` fails to start:

```sh
Error loading shared library libsasl2.so.3: No such file or directory (needed by /usr/src/openwec/./openwecd)
Error relocating ./openwecd: sasl_client_new: symbol not found
...
```